### PR TITLE
Vamp Router with SSL Support

### DIFF
--- a/configuration/templates/haproxy_config.template
+++ b/configuration/templates/haproxy_config.template
@@ -14,6 +14,18 @@ global
  #
  #
  log /var/run/vamp.log.sock local0
+ 
+ 
+ # Default SSL material locations
+ ca-base /etc/ssl/certs
+ crt-base /etc/ssl/private
+
+ # Default ciphers to use on SSL-enabled listening sockets.
+ # For more information, see ciphers(1SSL). This list is from:
+ #  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+ ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
+ ssl-default-bind-options no-sslv3
+ tune.ssl.default-dh-param 1024
 
  defaults
    log global
@@ -52,7 +64,9 @@ frontend {{.Name}}
     {{ if eq .Mode "http" }} option httplog {{end}}
     {{ if eq .Mode "tcp" }} option tcplog {{end}}
     
-    {{if .BindSsl}} reqadd X-Forwarded-Proto:\ https
+    {{if .BindSsl}}
+    reqadd X-Forwarded-Proto:\ https
+    {{end}}
 
     ###
     #

--- a/configuration/templates/haproxy_config.template
+++ b/configuration/templates/haproxy_config.template
@@ -46,12 +46,13 @@ listen stats :1988
 {{range .Frontends}}
 frontend {{.Name}}
     {{if .BindIp}}
-    bind {{.BindIp}}:{{.BindPort}}
+    bind {{.BindIp}}:{{.BindPort}}{{if .BindSsl}} ssl crt /etc/ssl/private/{{.Name}}.pem{{end}}
     {{end}}
 
     {{ if eq .Mode "http" }} option httplog {{end}}
     {{ if eq .Mode "tcp" }} option tcplog {{end}}
-
+    
+    {{if .BindSsl}} reqadd X-Forwarded-Proto:\ https
 
     ###
     #
@@ -60,7 +61,6 @@ frontend {{.Name}}
     # capture request header X-Vamp-Server-CurrentTime len 50
     # capture response header X-Vamp-Server-ResponseTime len 50
     # capture response header X-Vamp-Server-Name len 50
-
 
     log-format {\ "timestamp"\ :\ %t,\ "frontend"\ :\ "%f",\ "method"\ :\ "%r",\ "captured_request_headers"\ :\ "%hrl",\ "captures_response_headers"\ :\ "%hsl"\ }
 

--- a/haproxy/factories.go
+++ b/haproxy/factories.go
@@ -9,13 +9,14 @@ const (
 )
 
 // creates a Frontend object
-func (c *Config) frontendFactory(name string, mode string, port int, filter []*Filter, backend *Backend) *Frontend {
+func (c *Config) frontendFactory(name string, mode string, port int, ssl bool, filter []*Filter, backend *Backend) *Frontend {
 
 	return &Frontend{
 		Name:           name,
 		Mode:           mode,
 		BindPort:       port,
 		BindIp:         "0.0.0.0",
+		BindSsl:		ssl,
 		Options:        ProxyOptions{},
 		DefaultBackend: backend.Name,
 		Filters:        filter,

--- a/haproxy/factories.go
+++ b/haproxy/factories.go
@@ -16,7 +16,7 @@ func (c *Config) frontendFactory(name string, mode string, port int, ssl bool, f
 		Mode:           mode,
 		BindPort:       port,
 		BindIp:         "0.0.0.0",
-		BindSsl:		ssl,
+		BindSsl:        ssl,
 		Options:        ProxyOptions{},
 		DefaultBackend: backend.Name,
 		Filters:        filter,

--- a/haproxy/routes.go
+++ b/haproxy/routes.go
@@ -58,7 +58,7 @@ func (c *Config) AddRoute(route Route) *Error {
 		return &Error{400, err}
 	}
 
-	stableFrontend := c.frontendFactory(route.Name, route.Protocol, route.Port, resolvedFilters, stableBackend)
+	stableFrontend := c.frontendFactory(route.Name, route.Protocol, route.Port, route.Ssl, resolvedFilters, stableBackend)
 	feSlice = append(feSlice, stableFrontend)
 	/*
 

--- a/haproxy/structs.go
+++ b/haproxy/structs.go
@@ -33,6 +33,7 @@ type Route struct {
 	Name      string     `json:"name" binding:"required" valid:"routeName"`
 	Port      int        `json:"port" binding:"required"`
 	Protocol  string     `json:"protocol" binding:"required"`
+	Ssl       bool       `json:"ssl"`
 	HttpQuota Quota      `json:"httpQuota"`
 	TcpQuota  Quota      `json:"tcpQuota"`
 	Filters   []*Filter  `json:"filters"`
@@ -107,6 +108,7 @@ type Frontend struct {
 	Mode           string       `json:"mode" binding:"required"`
 	BindPort       int          `json:"bindPort"`
 	BindIp         string       `json:"bindIp"`
+	BindSsl        bool         `json:"bindSsl"`
 	UnixSock       string       `json:"unixSock"`
 	SockProtocol   string       `json:"sockProtocol"`
 	Options        ProxyOptions `json:"options"`

--- a/test/test_route.json
+++ b/test/test_route.json
@@ -2,6 +2,7 @@
       "name": "test_route_2",
       "port": 9026,
       "protocol": "http",
+      "ssl": true,
       "filters": [
         {
           "name": "uses_internet_explorer",


### PR DESCRIPTION
This is an initial try to get ssl support native in the Vamp Router. Let me know what you think. The next step will be support to set this using Vamp Core.

This supports only the scenario `[client]--https-->[vamp-router]--http-->[service]`

When the route has ssl set to true it will add `... ssl /etc/ssl/private/{{route name}}.pem` to the binding.

``` json
{
  "name": "www.example.com",
  "port": 443,
  "protocol": "http",
  "ssl": true
}
```

_Note: I had to update HAProxy to at least 1.5.7 but I picked the latest (1.5.12) release instead due to some bug fixes._
